### PR TITLE
DDCE-8594-Updated sign-out & time-out to use bas-gateway endpoints for register-estate-details-frontend

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -30,6 +30,11 @@ class FrontendAppConfig @Inject() (configuration: Configuration) {
   lazy val loginContinueUrl: String = configuration.get[String]("urls.loginContinue")
   lazy val logoutUrl: String        = configuration.get[String]("urls.logout")
 
+  lazy val basGatewayBaseUrl: String       = configuration.get[String]("bas-gateway.host")
+  lazy val feedbackFrontendUrl: String     = configuration.get[String]("feedback-frontend.url")
+  lazy val timeOutUrl: String              = configuration.get[String]("urls.timeOut")
+  lazy val logoutWithBasGatewayUrl: String = s"$basGatewayBaseUrl$logoutUrl"
+
   lazy val logoutAudit: Boolean =
     configuration.get[Boolean]("microservice.services.features.auditing.logout")
 

--- a/app/controllers/LogoutController.scala
+++ b/app/controllers/LogoutController.scala
@@ -59,7 +59,7 @@ class LogoutController @Inject() (
 
     }
 
-    Redirect(appConfig.logoutUrl).withSession(session = ("feedbackId", Session.id(hc)))
+    Redirect(appConfig.logoutWithBasGatewayUrl, Map("continue" -> Seq(appConfig.feedbackFrontendUrl)))
 
   }
 

--- a/app/controllers/SessionTimeoutController.scala
+++ b/app/controllers/SessionTimeoutController.scala
@@ -42,7 +42,12 @@ class SessionTimeoutController @Inject() (
     logger.info(
       s"[Session ID: ${Session.id(hc)}] user has not requested to extend their session, user has been signed out"
     )
-    Future.successful(Redirect(controllers.routes.SessionExpiredController.onPageLoad.url).withNewSession)
+    Future.successful(
+      Redirect(
+        appConfig.logoutWithBasGatewayUrl,
+        Map("continue" -> Seq(appConfig.timeOutUrl))
+      )
+    )
   }
 
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -102,6 +102,6 @@ urls {
   loginContinue = "http://localhost:9000/register-estate-details-frontend"
   logout        = "/gg/sign-out"
   registerEstateHubOverview = "http://localhost:8822/register-an-estate/registration-progress"
-  timeOut       = "http://localhost:8822/register-an-estate/this-service-has-been-reset"
+  timeOut       = "http://localhost:8823/register-an-estate/this-service-has-been-reset"
 }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -83,6 +83,14 @@ mongodb {
   timeToLiveInSeconds = 3600
 }
 
+bas-gateway {
+  host = "http://localhost:9553"
+}
+
+feedback-frontend {
+  url = "http://localhost:9514/feedback/estates"
+}
+
 timeout{
   length = 900
   countdown = 120
@@ -92,7 +100,8 @@ timeout{
 urls {
   login         = "http://localhost:9949/auth-login-stub/gg-sign-in"
   loginContinue = "http://localhost:9000/register-estate-details-frontend"
-  logout        = "http://localhost:9514/feedback/estates"
+  logout        = "/gg/sign-out"
   registerEstateHubOverview = "http://localhost:8822/register-an-estate/registration-progress"
+  timeOut       = "http://localhost:8822/register-an-estate/this-service-has-been-reset"
 }
 

--- a/test/controllers/LogoutControllerSpec.scala
+++ b/test/controllers/LogoutControllerSpec.scala
@@ -25,9 +25,15 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 
+import java.net.URLEncoder
+
 class LogoutControllerSpec extends SpecBase with MockitoSugar {
 
   "LogoutController" when {
+
+    val continueUrl = URLEncoder.encode(s"${frontendAppConfig.feedbackFrontendUrl}", "UTF-8")
+
+    val expectedUrl = s"${frontendAppConfig.logoutWithBasGatewayUrl}?continue=$continueUrl"
 
     "auditing enabled" must {
       "redirect to feedback and audit" in {
@@ -45,7 +51,7 @@ class LogoutControllerSpec extends SpecBase with MockitoSugar {
 
         status(result) mustEqual SEE_OTHER
 
-        redirectLocation(result).value mustBe frontendAppConfig.logoutUrl
+        redirectLocation(result).value mustBe expectedUrl
 
         verify(mockAuditConnector)
           .sendExplicitAudit(eqTo("estates"), any[Map[String, String]])(any(), any())
@@ -71,7 +77,7 @@ class LogoutControllerSpec extends SpecBase with MockitoSugar {
 
         status(result) mustEqual SEE_OTHER
 
-        redirectLocation(result).value mustBe frontendAppConfig.logoutUrl
+        redirectLocation(result).value mustBe expectedUrl
 
         verify(mockAuditConnector, never)
           .sendExplicitAudit(eqTo("estates"), any[Map[String, String]])(any(), any())

--- a/test/controllers/SessionTimeoutControllerSpec.scala
+++ b/test/controllers/SessionTimeoutControllerSpec.scala
@@ -23,6 +23,8 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.api.{Configuration, Environment}
 
+import java.net.URLEncoder
+
 class SessionTimeoutControllerSpec extends SpecBase {
 
   object TestSessionTimeoutController
@@ -47,8 +49,10 @@ class SessionTimeoutControllerSpec extends SpecBase {
       "the timeout method is" in {
         val fakeRequest: Request[AnyContent] = FakeRequest().withSession()
         val res                              = TestSessionTimeoutController.timeout(fakeRequest)
+        val continueUrl                      = URLEncoder.encode(s"${frontendAppConfig.timeOutUrl}", "UTF-8")
+        val expectedUrl                      = s"${frontendAppConfig.logoutWithBasGatewayUrl}?continue=$continueUrl"
         status(res) mustEqual SEE_OTHER
-        redirectLocation(res).value mustEqual controllers.routes.SessionExpiredController.onPageLoad.url
+        redirectLocation(res).value mustEqual expectedUrl
       }
     }
   }


### PR DESCRIPTION
Updated sign-out & time-out to use bas-gateway endpoints for register-estate-details-frontend